### PR TITLE
fixes #47

### DIFF
--- a/bin/graph_tool_parser.py
+++ b/bin/graph_tool_parser.py
@@ -78,8 +78,10 @@ def filter_diamond(g, module, filter_column):
 
 
 def filter_domino(g, module, filter_column):
+    module_ids = []
     with open(module, "r") as file:
-        module_ids = [id.strip("entrez.") for id in file.readline().strip("[]\n").split(", ")]
+        for line in file:
+            module_ids += [id.strip("entrez.") for id in line.strip("[]\n").split(", ")]
     gt.map_property_values(g.vp.name, g.vp[filter_column], lambda name: name in module_ids)
     return g
 


### PR DESCRIPTION
Currently, the module parser reads only the first line of the domino output.
In this fix, the script iterates over all lines of the domino output.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/REPO4EU/modulediscovery/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
